### PR TITLE
SMBL 1.4

### DIFF
--- a/smbl/fasta/fasta.snake
+++ b/smbl/fasta/fasta.snake
@@ -1,26 +1,11 @@
 import smbl
 
-rule index_fa:
-	output:
-		"{filename}.fa.fai"
-	input:
-		smbl.prog.SAMTOOLS,
-		"{filename}.fa"
-	message:
-		"Creating index for a FASTA file ({input[1]})."
-	shell:
-		"""
-			(
-				"{input[0]}" faidx "{input[1]}"
-			) > /dev/null
-		"""
-
 rule index_fasta:
 	output:
-		"{filename}.fasta.fai"
+		"{filename}.{suffix}.fai"
 	input:
 		smbl.prog.SAMTOOLS,
-		"{filename}.fasta"
+		"{filename}.{suffix}"
 	message:
 		"Creating index for a FASTA file ({input[1]})."
 	shell:
@@ -32,10 +17,10 @@ rule index_fasta:
 
 rule index_bam_bai:
 	output:
-		"{filename}.bam.bai"
+		"{filename}.{suffix}.bai"
 	input:
 		smbl.prog.SAMTOOLS,
-		"{filename}.bam"
+		"{filename}.{suffix}"
 	message:
 		"Creating index for a BAM file ({input[1]})."
 	shell:
@@ -47,10 +32,10 @@ rule index_bam_bai:
 
 rule index_bam_csi:
 	output:
-		"{filename}.bam.csi"
+		"{filename}.{suffix}.csi"
 	input:
 		smbl.prog.SAMTOOLS,
-		"{filename}.bam"
+		"{filename}.{suffix}"
 	message:
 		"Creating index for a BAM file ({input[1]})."
 	shell:
@@ -59,38 +44,3 @@ rule index_bam_csi:
 				"{input[0]}" index -c "{input[1]}"
 			) > /dev/null
 		"""
-
-#for i, fasta in enumerate(smbl.fasta.get_registered_fastas()):
-#	rule:
-#		output:
-#			fasta.get()
-#		input:
-#			fasta.get_required_programs()
-#		params:
-#			i=str(i),
-#		run:
-#			smbl.fasta.get_registered_fastas()[int(params.i)].install_all_steps()
-
-#rule human_hg38:
-#	input:
-#		smbl.prog.TWOBITTOFA
-#	output:
-#		smbl.fasta.HUMAN_HG38
-#	message:
-#		"Installing the Human genome (HG38)."
-#	params:
-#		src=smbl.src_dir,
-#	shell:
-#		"""
-#			(
-#				rm -fR "{params.src}/hg38"
-#				mkdir -p "{params.src}/hg38"
-#			) > /dev/null
-#
-#			curl -L --insecure -o "{params.src}/hg38/hg38.2bit" "http://hgdownload.cse.ucsc.edu/goldenPath/hg38/bigZips/hg38.2bit"
-#
-#			(
-#				"{input[0]}" "{params.src}/hg38/hg38.2bit" "{output[0]}"
-#				rm -fR "{params.src}/hg38"
-#			) > /dev/null
-#		"""

--- a/smbl/prog/plugins/bcftools.py
+++ b/smbl/prog/plugins/bcftools.py
@@ -27,8 +27,8 @@ class BcfTools(Program):
 
 	@classmethod
 	def install(cls):
-		gitdir_bcftools=cls.git_clone("git://github.com/samtools/bcftools","bcftools")
-		gitdir_htslib=cls.git_clone("git://github.com/samtools/htslib","htslib")
+		gitdir_bcftools=cls.git_clone("http://github.com/samtools/bcftools","bcftools")
+		gitdir_htslib=cls.git_clone("http://github.com/samtools/htslib","htslib")
 		cls.run_make("bcftools")
 		cls.install_file("bcftools/bcftools",BCFTOOLS)
 		cls.install_file("bcftools/vcfutils.pl",VCFUTILS)

--- a/smbl/prog/plugins/bfast.py
+++ b/smbl/prog/plugins/bfast.py
@@ -22,7 +22,7 @@ class BFast(Program):
 
 	@classmethod
 	def install(cls):
-		gitdir_bcftools=cls.git_clone("git://github.com/nh13/bfast","")
+		gitdir_bcftools=cls.git_clone("http://github.com/nh13/bfast","")
 		smbl.utils.shell('(cd "{}" && sh autogen.sh) > /dev/null'.format(cls.src_dir))
 		cls.run_configure("")
 		cls.run_make("")

--- a/smbl/prog/plugins/bowtie.py
+++ b/smbl/prog/plugins/bowtie.py
@@ -37,7 +37,7 @@ class Bowtie2(Program):
 
 	@classmethod
 	def install(cls):
-		gitdir_bcftools=cls.git_clone("git://github.com/BenLangmead/bowtie2","")
+		gitdir_bcftools=cls.git_clone("http://github.com/BenLangmead/bowtie2","")
 		cls.run_make("")
 		cls.install_file("bowtie2",BOWTIE2)
 		cls.install_file("bowtie2-align-l",BOWTIE2_ALIGN_L)

--- a/smbl/prog/plugins/bwa.py
+++ b/smbl/prog/plugins/bwa.py
@@ -23,7 +23,7 @@ class Bwa(Program):
 
 	@classmethod
 	def install(cls):
-		cls.git_clone("git://github.com/lh3/bwa","bwa")
+		cls.git_clone("http://github.com/lh3/bwa","bwa")
 		cls.run_make("bwa")
 		cls.install_file("bwa/bwa",BWA)
 

--- a/smbl/prog/plugins/cmake.py
+++ b/smbl/prog/plugins/cmake.py
@@ -20,7 +20,7 @@ class CMake(Program):
 
 	@classmethod
 	def install(cls):
-		fn=cls.download_file("http://www.cmake.org/files/v3.2/cmake-3.2.3.tar.gz","cmake.tar.gz")
+		fn=cls.download_file("http://cmake.org/files/v3.3/cmake-3.3.2.tar.gz","cmake.tar.gz")
 		dir=cls.extract_tar(fn,strip=1)
 		cls.shell('cd "{dir}" && ./bootstrap --prefix="{install_dir}"'.format(dir=dir,install_dir=smbl.smbl_dir))
 		cls.run_make("")

--- a/smbl/prog/plugins/curesim.py
+++ b/smbl/prog/plugins/curesim.py
@@ -22,12 +22,20 @@ class CuReSim(Program):
 
 	@classmethod
 	def install(cls):
-		fn1=cls.download_file("http://www.pegase-biosciences.com/wp-content/uploads/2013/04/CuReSim1.2.zip","curesim.zip")
-		fn2=cls.download_file("http://www.pegase-biosciences.com/wp-content/uploads/2013/04/CuReSimEval1.1.zip","curesim_eval.zip")
-		dir=os.path.dirname(fn1)
-		smbl.utils.shell('(cd "{dir}" && unzip -j -o curesim.zip && unzip -j -o curesim_eval.zip) > /dev/null'.format(dir=dir))
+		try:
+			fn1=cls.download_file("http://www.pegase-biosciences.com/wp-content/uploads/2013/04/CuReSim1.2.zip","curesim.zip")
+			fn2=cls.download_file("http://www.pegase-biosciences.com/wp-content/uploads/2013/04/CuReSimEval1.1.zip","curesim_eval.zip")
+			dir=os.path.dirname(fn1)
+			smbl.utils.shell('(cd "{dir}" && unzip -j -o curesim.zip && unzip -j -o curesim_eval.zip) > /dev/null'.format(dir=dir))
+			cls.install_file("CuReSim.jar",CURESIM)
+			cls.install_file("CuReSimEval.jar",CURESIM_EVAL)
+		except:
+			fn1=cls.download_file("https://github.com/karel-brinda/ext-smbl/raw/master/CuReSim.jar","CuReSim.jar")
+			fn2=cls.download_file("https://github.com/karel-brinda/ext-smbl/raw/master/CuReSimEval.jar","CuReSimEval.jar")
+
 		cls.install_file("CuReSim.jar",CURESIM)
 		cls.install_file("CuReSimEval.jar",CURESIM_EVAL)
+
 
 	@classmethod
 	def supported_platforms(cls):

--- a/smbl/prog/plugins/curesim.py
+++ b/smbl/prog/plugins/curesim.py
@@ -30,8 +30,8 @@ class CuReSim(Program):
 			cls.install_file("CuReSim.jar",CURESIM)
 			cls.install_file("CuReSimEval.jar",CURESIM_EVAL)
 		except:
-			fn1=cls.download_file("https://github.com/karel-brinda/ext-smbl/raw/master/CuReSim.jar","CuReSim.jar")
-			fn2=cls.download_file("https://github.com/karel-brinda/ext-smbl/raw/master/CuReSimEval.jar","CuReSimEval.jar")
+			fn1=cls.download_file("http://github.com/karel-brinda/ext-smbl/raw/master/CuReSim.jar","CuReSim.jar")
+			fn2=cls.download_file("http://github.com/karel-brinda/ext-smbl/raw/master/CuReSimEval.jar","CuReSimEval.jar")
 
 		cls.install_file("CuReSim.jar",CURESIM)
 		cls.install_file("CuReSimEval.jar",CURESIM_EVAL)

--- a/smbl/prog/plugins/drfast.py
+++ b/smbl/prog/plugins/drfast.py
@@ -20,7 +20,7 @@ class DrFast(Program):
 
 	@classmethod
 	def install(cls):
-		cls.git_clone("git://github.com/BilkentCompGen/drfast","")
+		cls.git_clone("http://github.com/BilkentCompGen/drfast","")
 		cls.run_make("")
 		cls.install_file("drfast",DRFAST)
 

--- a/smbl/prog/plugins/dwgsim.py
+++ b/smbl/prog/plugins/dwgsim.py
@@ -27,7 +27,7 @@ class DwgSim(Program):
 
 	@classmethod
 	def install(cls):
-		gitdir=cls.git_clone("git://github.com/nh13/dwgsim","dwgsim")
+		gitdir=cls.git_clone("http://github.com/nh13/dwgsim","dwgsim")
 		smbl.prog.correct_samtools_make(os.path.join(gitdir,"samtools","Makefile"))
 		cls.run_make("dwgsim")
 		cls.install_file("dwgsim/dwgsim",DWGSIM)

--- a/smbl/prog/plugins/htslib.py
+++ b/smbl/prog/plugins/htslib.py
@@ -22,8 +22,8 @@ class HtsLib(Program):
 
 	@classmethod
 	def install(cls):
-		gitdir_bcftools=cls.git_clone("git://github.com/samtools/bcftools","bcftools")
-		gitdir_htslib=cls.git_clone("git://github.com/samtools/htslib","htslib")
+		gitdir_bcftools=cls.git_clone("http://github.com/samtools/bcftools","bcftools")
+		gitdir_htslib=cls.git_clone("http://github.com/samtools/htslib","htslib")
 		cls.run_make("htslib")
 		cls.install_file("htslib/tabix",TABIX)
 		cls.install_file("htslib/bgzip",BGZIP)

--- a/smbl/prog/plugins/kallisto.py
+++ b/smbl/prog/plugins/kallisto.py
@@ -34,7 +34,7 @@ class Kallisto(Program):
 
 	@classmethod
 	def install(cls):
-		gitdir=cls.git_clone("git://github.com/pachterlab/kallisto","kallisto")
+		gitdir=cls.git_clone("http://github.com/pachterlab/kallisto","kallisto")
 		cls.run_cmake("kallisto")
 		cls.run_make("kallisto")
 		cls.install_file("kallisto/src/kallisto",KALLISTO)

--- a/smbl/prog/plugins/last.py
+++ b/smbl/prog/plugins/last.py
@@ -22,7 +22,7 @@ class Last(Program):
 
 	@classmethod
 	def install(cls):
-		last_version="last-581"
+		last_version="last-638"
 		fn=cls.download_file("http://last.cbrc.jp/{}.zip".format(last_version),"last.zip")
 		dir1=os.path.dirname(fn)
 		smbl.utils.shell('(cd "{dir1}" && unzip last.zip)'.format(dir1=dir1))

--- a/smbl/prog/plugins/mrfast.py
+++ b/smbl/prog/plugins/mrfast.py
@@ -20,7 +20,7 @@ class MrFast(Program):
 
 	@classmethod
 	def install(cls):
-		cls.git_clone("git://github.com/BilkentCompGen/mrfast","")
+		cls.git_clone("http://github.com/BilkentCompGen/mrfast","")
 		cls.run_make("")
 		cls.install_file("mrfast",MRFAST)
 

--- a/smbl/prog/plugins/mrsfast.py
+++ b/smbl/prog/plugins/mrsfast.py
@@ -26,7 +26,7 @@ class MrsFast(Program):
 
 	@classmethod
 	def install(cls):
-		cls.git_clone("git://github.com/sfu-compbio/mrsfast/","")
+		cls.git_clone("http://github.com/sfu-compbio/mrsfast/","")
 		cls.run_make("")
 		cls.install_file("mrsfast",MRSFAST)
 

--- a/smbl/prog/plugins/picard.py
+++ b/smbl/prog/plugins/picard.py
@@ -20,7 +20,7 @@ class Picard(Program):
 
 	@classmethod
 	def install(cls):
-		ver="1.133"
+		ver="1.140"
 		fn=cls.download_file("https://github.com/broadinstitute/picard/releases/download/{ver}/picard-tools-{ver}.zip".format(ver=ver),"picard.zip")
 		dir=os.path.dirname(fn)
 		smbl.utils.shell('(cd "{dir}" && unzip -j picard.zip) > /dev/null'.format(dir=dir))

--- a/smbl/prog/plugins/sambamba.py
+++ b/smbl/prog/plugins/sambamba.py
@@ -20,7 +20,7 @@ class SamBamBa(Program):
 
 	@classmethod
 	def install(cls):
-		version="v0.5.4"
+		version="v0.5.8"
 
 		if smbl.utils.is_linux():
 			fn=cls.download_file("http://github.com/lomereiter/sambamba/releases/download/{ver}/sambamba_{ver}_linux.tar.bz2".format(ver=version),"sambamba.tar.bz2")

--- a/smbl/prog/plugins/samtools.py
+++ b/smbl/prog/plugins/samtools.py
@@ -20,8 +20,8 @@ class SamTools(Program):
 
 	@classmethod
 	def install(cls):
-		gitdir_samtools=cls.git_clone("git://github.com/samtools/samtools","samtools")
-		gitdir_htslib=cls.git_clone("git://github.com/samtools/htslib","htslib")
+		gitdir_samtools=cls.git_clone("http://github.com/samtools/samtools","samtools")
+		gitdir_htslib=cls.git_clone("http://github.com/samtools/htslib","htslib")
 		smbl.prog.correct_samtools_make(os.path.join(gitdir_samtools,"Makefile"))
 		cls.run_make("samtools")
 		cls.install_file("samtools/samtools",SAMTOOLS)

--- a/smbl/prog/plugins/seqan.py
+++ b/smbl/prog/plugins/seqan.py
@@ -54,7 +54,7 @@ class Seqan(Program):
 	@classmethod
 	def install(cls):
 
-		cls.git_clone("git://github.com/seqan/seqan","")
+		cls.git_clone("http://github.com/seqan/seqan","")
 
 		cls.run_cmake("")
 

--- a/smbl/prog/plugins/sirfast.py
+++ b/smbl/prog/plugins/sirfast.py
@@ -20,7 +20,7 @@ class SirFast(Program):
 
 	@classmethod
 	def install(cls):
-		cls.git_clone("git://github.com/BilkentCompGen/sirfast","")
+		cls.git_clone("http://github.com/BilkentCompGen/sirfast","")
 		cls.run_make("")
 		cls.install_file("sirfast",SIRFAST)
 

--- a/smbl/prog/plugins/wgsim.py
+++ b/smbl/prog/plugins/wgsim.py
@@ -22,7 +22,7 @@ class WgSim(Program):
 
 	@classmethod
 	def install(cls):
-		gitdir=cls.git_clone("git://github.com/lh3/wgsim","wgsim")
+		gitdir=cls.git_clone("http://github.com/lh3/wgsim","wgsim")
 		smbl.utils.shell('cd "{dir}" && gcc -g -O2 -Wall -o wgsim wgsim.c -lz -lm'.format(dir=gitdir))
 		cls.install_file("wgsim/wgsim",WGSIM)
 		cls.install_file("wgsim/wgsim_eval.pl",WGSIM_EVAL)

--- a/smbl/prog/plugins/xs.py
+++ b/smbl/prog/plugins/xs.py
@@ -20,8 +20,10 @@ class Xs(Program):
 
 	@classmethod
 	def install(cls):
-		fn=cls.download_file("http://bioinformatics.ua.pt/wp-content/uploads/2014/02/XS.tar.gz","xs.tar.gz")
-		#fn=cls.download_file("http://exon.ieeta.pt/xs/xs.tar.gz","xs.tar.gz")
+		try:
+			fn=cls.download_file("http://bioinformatics.ua.pt/wp-content/uploads/2014/02/XS.tar.gz","xs.tar.gz")
+		except:
+			fn=cls.download_file("http://exon.ieeta.pt/xs/xs.tar.gz","xs.tar.gz")
 		dir=cls.extract_tar(fn,strip=1)
 		cls.run_make(dir)
 		cls.install_file("XS",XS)


### PR DESCRIPTION
Minor technical improvements:
- support for `fai` and `bai` indexes for files with arbitrary suffixes (originally only for `.fa`, `.fasta`, `.bam`)
- HTTP protocol instead of Git for `git clone` (for users behind proxy)
- Github mirror (https://github.com/karel-brinda/ext-smbl) for unstable servers (e.g., for download of CuReSim)
- new version of CMake, LAST, Picard, SamBamba
